### PR TITLE
Accept pattern without `--pattern`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,15 +8,12 @@ import { run } from './run';
 const pkgJson = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
 
 const yarg = yargs
-  .usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $0 [options] <search directory>')
+  .usage('Create .css.d.ts from CSS modules *.css files.\nUsage: $0 [options] [file|dir|glob]')
   .example('$0 src/styles', '')
   .example('$0 src -o dist', '')
-  .example('$0 -p styles/**/*.icss -w', '')
+  .example("$0 'styles/**/*.icss' -w", '')
   .detectLocale(false)
   .demand(['_'])
-  .alias('p', 'pattern')
-  .describe('p', 'Glob pattern with css files')
-  .string('p')
   .alias('o', 'outDir')
   .describe('o', 'Output directory')
   .string('o')
@@ -50,18 +47,14 @@ async function main(): Promise<void> {
     return;
   }
 
-  let searchDir: string;
-  if (argv._ && argv._[0]) {
-    searchDir = argv._[0].toString();
-  } else if (argv.p) {
-    searchDir = './';
-  } else {
+  // TODO: support multiple patterns
+  const patterns: string[] = argv._.map((pattern) => pattern.toString());
+  if (patterns.length !== 1) {
     yarg.showHelp();
     return;
   }
 
-  await run(searchDir, {
-    pattern: argv.p,
+  await run(patterns[0], {
     outDir: argv.o,
     watch: argv.w,
     camelCase: argv.c,

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -20,7 +20,6 @@ export type CamelCaseOption = boolean | 'dashes' | undefined;
 interface DtsContentOptions {
   declarationMap: boolean;
   rootDir: string;
-  pattern: string;
   outDir: string;
   rInputPath: string;
   rawTokenList: ExportToken[];
@@ -32,7 +31,6 @@ interface DtsContentOptions {
 export class DtsContent {
   private declarationMap: boolean;
   private rootDir: string;
-  private pattern: string;
   private outDir: string;
   private rInputPath: string;
   private rawTokenList: ExportToken[];
@@ -44,7 +42,6 @@ export class DtsContent {
   constructor(options: DtsContentOptions) {
     this.declarationMap = options.declarationMap;
     this.rootDir = options.rootDir;
-    this.pattern = options.pattern;
     this.outDir = options.outDir;
     this.rInputPath = options.rInputPath;
     this.rawTokenList = options.rawTokenList;

--- a/src/dts-content.ts
+++ b/src/dts-content.ts
@@ -20,7 +20,7 @@ export type CamelCaseOption = boolean | 'dashes' | undefined;
 interface DtsContentOptions {
   declarationMap: boolean;
   rootDir: string;
-  searchDir: string;
+  pattern: string;
   outDir: string;
   rInputPath: string;
   rawTokenList: ExportToken[];
@@ -32,7 +32,7 @@ interface DtsContentOptions {
 export class DtsContent {
   private declarationMap: boolean;
   private rootDir: string;
-  private searchDir: string;
+  private pattern: string;
   private outDir: string;
   private rInputPath: string;
   private rawTokenList: ExportToken[];
@@ -44,7 +44,7 @@ export class DtsContent {
   constructor(options: DtsContentOptions) {
     this.declarationMap = options.declarationMap;
     this.rootDir = options.rootDir;
-    this.searchDir = options.searchDir;
+    this.pattern = options.pattern;
     this.outDir = options.outDir;
     this.rInputPath = options.rInputPath;
     this.rawTokenList = options.rawTokenList;
@@ -85,7 +85,7 @@ export class DtsContent {
   }
 
   public get inputFilePath(): string {
-    return path.join(this.rootDir, this.searchDir, this.rInputPath);
+    return path.join(this.rootDir, this.rInputPath);
   }
 
   public async writeFile(): Promise<void> {

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -7,7 +7,7 @@ import FileSystemLoader from './library/css-modules-loader-core/file-system-load
 
 interface DtsCreatorOptions {
   rootDir?: string;
-  searchDir?: string;
+  pattern?: string;
   outDir?: string;
   camelCase?: CamelCaseOption;
   namedExport?: boolean;
@@ -19,7 +19,7 @@ interface DtsCreatorOptions {
 
 export class DtsCreator {
   private rootDir: string;
-  private searchDir: string;
+  private pattern: string;
   private outDir: string;
   private loader: FileSystemLoader;
   private inputDirectory: string;
@@ -32,10 +32,10 @@ export class DtsCreator {
   constructor(options?: DtsCreatorOptions) {
     if (!options) options = {};
     this.rootDir = options.rootDir || process.cwd();
-    this.searchDir = options.searchDir || '';
-    this.outDir = options.outDir || this.searchDir;
+    this.pattern = options.pattern || '';
+    this.outDir = options.outDir || '.';
     this.loader = new FileSystemLoader(this.rootDir, options.loaderPlugins);
-    this.inputDirectory = path.join(this.rootDir, this.searchDir);
+    this.inputDirectory = this.rootDir;
     this.outputDirectory = path.join(this.rootDir, this.outDir);
     this.camelCase = options.camelCase;
     this.namedExport = !!options.namedExport;
@@ -63,7 +63,7 @@ export class DtsCreator {
       const content = new DtsContent({
         declarationMap: this.declarationMap,
         rootDir: this.rootDir,
-        searchDir: this.searchDir,
+        pattern: this.pattern,
         outDir: this.outDir,
         rInputPath,
         rawTokenList,

--- a/src/dts-creator.ts
+++ b/src/dts-creator.ts
@@ -7,7 +7,6 @@ import FileSystemLoader from './library/css-modules-loader-core/file-system-load
 
 interface DtsCreatorOptions {
   rootDir?: string;
-  pattern?: string;
   outDir?: string;
   camelCase?: CamelCaseOption;
   namedExport?: boolean;
@@ -19,7 +18,6 @@ interface DtsCreatorOptions {
 
 export class DtsCreator {
   private rootDir: string;
-  private pattern: string;
   private outDir: string;
   private loader: FileSystemLoader;
   private inputDirectory: string;
@@ -32,7 +30,6 @@ export class DtsCreator {
   constructor(options?: DtsCreatorOptions) {
     if (!options) options = {};
     this.rootDir = options.rootDir || process.cwd();
-    this.pattern = options.pattern || '';
     this.outDir = options.outDir || '.';
     this.loader = new FileSystemLoader(this.rootDir, options.loaderPlugins);
     this.inputDirectory = this.rootDir;
@@ -63,7 +60,6 @@ export class DtsCreator {
       const content = new DtsContent({
         declarationMap: this.declarationMap,
         rootDir: this.rootDir,
-        pattern: this.pattern,
         outDir: this.outDir,
         rInputPath,
         rawTokenList,

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import * as util from 'util';
 import chalk from 'chalk';
 import * as chokidar from 'chokidar';
@@ -9,7 +8,6 @@ import { DtsCreator } from './dts-creator';
 const glob = util.promisify(_glob);
 
 interface RunOptions {
-  pattern?: string;
   outDir?: string;
   watch?: boolean;
   camelCase?: boolean;
@@ -19,12 +17,10 @@ interface RunOptions {
   silent?: boolean;
 }
 
-export async function run(searchDir: string, options: RunOptions = {}): Promise<void> {
-  const filesPattern = path.join(searchDir, options.pattern || '**/*.css');
-
+export async function run(pattern: string, options: RunOptions = {}): Promise<void> {
   const creator = new DtsCreator({
     rootDir: process.cwd(),
-    searchDir,
+    pattern,
     outDir: options.outDir,
     camelCase: options.camelCase,
     namedExport: options.namedExport,
@@ -46,12 +42,12 @@ export async function run(searchDir: string, options: RunOptions = {}): Promise<
   };
 
   if (!options.watch) {
-    const files = await glob(filesPattern);
+    const files = await glob(pattern);
     await Promise.all(files.map(writeFile));
   } else {
-    console.log('Watch ' + filesPattern + '...');
+    console.log('Watch ' + pattern + '...');
 
-    const watcher = chokidar.watch([filesPattern.replace(/\\/g, '/')]);
+    const watcher = chokidar.watch([pattern.replace(/\\/g, '/')]);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     watcher.on('add', writeFile);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/src/run.ts
+++ b/src/run.ts
@@ -20,7 +20,6 @@ interface RunOptions {
 export async function run(pattern: string, options: RunOptions = {}): Promise<void> {
   const creator = new DtsCreator({
     rootDir: process.cwd(),
-    pattern,
     outDir: options.outDir,
     camelCase: options.camelCase,
     namedExport: options.namedExport,

--- a/test/dts-creator.spec.ts
+++ b/test/dts-creator.spec.ts
@@ -49,10 +49,11 @@ describe('DtsCreator', () => {
 
   describe('#modify path', () => {
     it('can be set outDir', async () => {
-      const content = await new DtsCreator({ searchDir: 'test', outDir: 'dist' }).create(
-        path.normalize('test/testStyle.css'),
+      const content = await new DtsCreator({ outDir: 'dist' }).create(path.normalize('test/testStyle.css'));
+      assert.equal(
+        path.relative(process.cwd(), content.outputFilePath),
+        path.normalize('dist/test/testStyle.css.d.ts'),
       );
-      assert.equal(path.relative(process.cwd(), content.outputFilePath), path.normalize('dist/testStyle.css.d.ts'));
     });
   });
 });


### PR DESCRIPTION
close: https://github.com/mizdra/checkable-css-modules/issues/38

## BREAKING CHANGES
- Obsolete `--pattern`
- Obsolete `DtsContent#searchDir`
- Obsolete `DtsContentOptions#searchDir`
- Obsolete `DtsCreator#searchDir`
- Obsolete `DtsCreatorOptions#searchDir`
- When using `DtsCreatorOptions#outDir`, the output file path is no longer squashed using the `DtsCreatorOptions#searchDir` directory.
